### PR TITLE
Recursively flatten multiple nested one_of strategies in ghostwriter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ their individual contributions.
 * `Benjamin Lee <https://github.com/Benjamin-Lee>`_ (benjamindlee@me.com)
 * `Benjamin Palmer <https://github.com/benjpalmer>`_
 * `Bex Dunn <https://github.com/BexDunn>`_ (bex.dunn@gmail.com)
+* `Helpful Assistant <https://github.com/human-uplift>`_
 * `Bill Tucker <https://github.com/imbilltucker>`_ (imbilltucker@gmail.com)
 * `Brandon Chinn <https://github.com/brandonchinn178>`_
 * `Bryant Eisenbach <https://github.com/fubuloubu>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch enhances the :doc:`the Ghostwriter <ghostwriter>` module to recursively
+flatten multiple nested :func:`~hypothesis.strategies.one_of` strategies.
+Previously, it would only flatten a single level of nesting, which could lead
+to unnecessarily complex strategy representations in the generated code.


### PR DESCRIPTION
## Issue

The ghostwriter module could only flatten a single level of nested 'one_of' strategies in generated code. This PR enhances it to recursively flatten multiple levels of nesting, resulting in cleaner generated code.

## Changes

- Modified '_valid_syntax_repr' function in 'hypothesis/extra/ghostwriter.py' to recursively flatten nested 'one_of' strategies
- Added a new test case 'test_flattens_multiple_nested_one_of' that specifically tests flattening multiple levels of nested 'one_of' strategies

## Implementation

The new implementation recursively searches for nested 'one_of' strategies and flattens them into a single 'one_of' call. This avoids unnecessarily complex output like:



and instead produces:



## Testing Instructions

1. Clone the repository and checkout the PR branch
2. Run the following commands to set up your environment:
   Requirement already satisfied: attrs==24.1.0 in /usr/local/lib/python3.12/site-packages (from -r requirements/test.in (line 1)) (24.1.0)
Requirement already satisfied: pexpect in /usr/local/lib/python3.12/site-packages (from -r requirements/test.in (line 2)) (4.9.0)
Requirement already satisfied: pytest in /usr/local/lib/python3.12/site-packages (from -r requirements/test.in (line 3)) (8.3.5)
Requirement already satisfied: pytest-xdist in /usr/local/lib/python3.12/site-packages (from -r requirements/test.in (line 4)) (3.6.1)
Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.12/site-packages (from pexpect->-r requirements/test.in (line 2)) (0.7.0)
Requirement already satisfied: iniconfig in /usr/local/lib/python3.12/site-packages (from pytest->-r requirements/test.in (line 3)) (2.1.0)
Requirement already satisfied: packaging in /usr/local/lib/python3.12/site-packages (from pytest->-r requirements/test.in (line 3)) (24.2)
Requirement already satisfied: pluggy<2,>=1.5 in /usr/local/lib/python3.12/site-packages (from pytest->-r requirements/test.in (line 3)) (1.5.0)
Requirement already satisfied: execnet>=2.1 in /usr/local/lib/python3.12/site-packages (from pytest-xdist->-r requirements/test.in (line 4)) (2.1.1)
Requirement already satisfied: codespell in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 1)) (2.4.1)
Requirement already satisfied: coverage in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 2)) (7.8.0)
Requirement already satisfied: django in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 3)) (5.2)
Requirement already satisfied: dpcontracts in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 4)) (0.6.0)
Requirement already satisfied: ipython in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 5)) (9.1.0)
Requirement already satisfied: lark in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 6)) (1.2.2)
Requirement already satisfied: libcst in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 7)) (1.7.0)
Requirement already satisfied: mypy in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 8)) (1.15.0)
Requirement already satisfied: numpy in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 9)) (2.2.4)
Requirement already satisfied: pip-tools in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 11)) (7.4.1)
Requirement already satisfied: pyright in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 12)) (1.1.399)
Requirement already satisfied: python-dateutil in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 13)) (2.9.0.post0)
Requirement already satisfied: requests in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 14)) (2.32.3)
Requirement already satisfied: restructuredtext-lint in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 15)) (1.4.0)
Requirement already satisfied: ruff in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 16)) (0.11.5)
Requirement already satisfied: shed==2024.1.1 in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 17)) (2024.1.1)
Requirement already satisfied: sphinx in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 18)) (8.2.3)
Requirement already satisfied: sphinx-codeautolink in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 19)) (0.17.4)
Requirement already satisfied: sphinx-hoverxref in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 20)) (1.4.2)
Requirement already satisfied: sphinx-jsonschema in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 21)) (1.19.1)
Requirement already satisfied: sphinx-rtd-theme in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 22)) (3.0.2)
Requirement already satisfied: sphinx-selective-exclude in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 23)) (1.0.3)
Requirement already satisfied: tox in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 24)) (4.25.0)
Requirement already satisfied: twine in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 25)) (6.1.0)
Requirement already satisfied: types-click in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 26)) (7.1.8)
Requirement already satisfied: types-pytz in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 27)) (2025.2.0.20250326)
Requirement already satisfied: types-redis in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 28)) (4.6.0.20241004)
Requirement already satisfied: typing-extensions in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 29)) (4.13.2)
Requirement already satisfied: watchdog in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 30)) (6.0.0)
Requirement already satisfied: attrs==24.1.0 in /usr/local/lib/python3.12/site-packages (from -r /hypothesis/requirements/test.in (line 1)) (24.1.0)
Requirement already satisfied: pexpect in /usr/local/lib/python3.12/site-packages (from -r /hypothesis/requirements/test.in (line 2)) (4.9.0)
Requirement already satisfied: pytest in /usr/local/lib/python3.12/site-packages (from -r /hypothesis/requirements/test.in (line 3)) (8.3.5)
Requirement already satisfied: pytest-xdist in /usr/local/lib/python3.12/site-packages (from -r /hypothesis/requirements/test.in (line 4)) (3.6.1)
Requirement already satisfied: pelican[markdown] in /usr/local/lib/python3.12/site-packages (from -r requirements/tools.in (line 10)) (4.11.0)
Requirement already satisfied: autoflake>=1.4 in /usr/local/lib/python3.12/site-packages (from shed==2024.1.1->-r requirements/tools.in (line 17)) (2.3.1)
Requirement already satisfied: black>=24.1.0 in /usr/local/lib/python3.12/site-packages (from shed==2024.1.1->-r requirements/tools.in (line 17)) (25.1.0)
Requirement already satisfied: com2ann>=0.3.0 in /usr/local/lib/python3.12/site-packages (from shed==2024.1.1->-r requirements/tools.in (line 17)) (0.3.0)
Requirement already satisfied: isort>=5.10.1 in /usr/local/lib/python3.12/site-packages (from shed==2024.1.1->-r requirements/tools.in (line 17)) (6.0.1)
Requirement already satisfied: pyupgrade>=3.15.0 in /usr/local/lib/python3.12/site-packages (from shed==2024.1.1->-r requirements/tools.in (line 17)) (3.19.1)
Requirement already satisfied: asgiref>=3.8.1 in /usr/local/lib/python3.12/site-packages (from django->-r requirements/tools.in (line 3)) (3.8.1)
Requirement already satisfied: sqlparse>=0.3.1 in /usr/local/lib/python3.12/site-packages (from django->-r requirements/tools.in (line 3)) (0.5.3)
Requirement already satisfied: decorator in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (5.2.1)
Requirement already satisfied: ipython-pygments-lexers in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (1.1.1)
Requirement already satisfied: jedi>=0.16 in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (0.19.2)
Requirement already satisfied: matplotlib-inline in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (0.1.7)
Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (3.0.50)
Requirement already satisfied: pygments>=2.4.0 in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (2.18.0)
Requirement already satisfied: stack_data in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (0.6.3)
Requirement already satisfied: traitlets>=5.13.0 in /usr/local/lib/python3.12/site-packages (from ipython->-r requirements/tools.in (line 5)) (5.14.3)
Requirement already satisfied: pyyaml>=5.2 in /usr/local/lib/python3.12/site-packages (from libcst->-r requirements/tools.in (line 7)) (6.0.2)
Requirement already satisfied: mypy_extensions>=1.0.0 in /usr/local/lib/python3.12/site-packages (from mypy->-r requirements/tools.in (line 8)) (1.0.0)
Requirement already satisfied: blinker>=1.7.0 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (1.9.0)
Requirement already satisfied: docutils>=0.20.1 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (0.21.2)
Requirement already satisfied: feedgenerator>=2.1.0 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (2.1.0)
Requirement already satisfied: jinja2>=3.1.2 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (3.1.6)
Requirement already satisfied: ordered-set>=4.1.0 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (4.1.0)
Requirement already satisfied: rich>=13.6.0 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (14.0.0)
Requirement already satisfied: unidecode>=1.3.7 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (1.3.8)
Requirement already satisfied: watchfiles>=0.21.0 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (1.0.5)
Requirement already satisfied: markdown>=3.1 in /usr/local/lib/python3.12/site-packages (from pelican[markdown]->-r requirements/tools.in (line 10)) (3.8)
Requirement already satisfied: build>=1.0.0 in /usr/local/lib/python3.12/site-packages (from pip-tools->-r requirements/tools.in (line 11)) (1.2.2.post1)
Requirement already satisfied: click>=8 in /usr/local/lib/python3.12/site-packages (from pip-tools->-r requirements/tools.in (line 11)) (8.1.8)
Requirement already satisfied: pip>=22.2 in /usr/local/lib/python3.12/site-packages (from pip-tools->-r requirements/tools.in (line 11)) (24.3.1)
Requirement already satisfied: pyproject-hooks in /usr/local/lib/python3.12/site-packages (from pip-tools->-r requirements/tools.in (line 11)) (1.2.0)
Requirement already satisfied: setuptools in /usr/local/lib/python3.12/site-packages (from pip-tools->-r requirements/tools.in (line 11)) (78.1.0)
Requirement already satisfied: wheel in /usr/local/lib/python3.12/site-packages (from pip-tools->-r requirements/tools.in (line 11)) (0.45.1)
Requirement already satisfied: nodeenv>=1.6.0 in /usr/local/lib/python3.12/site-packages (from pyright->-r requirements/tools.in (line 12)) (1.9.1)
Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/site-packages (from python-dateutil->-r requirements/tools.in (line 13)) (1.17.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.12/site-packages (from requests->-r requirements/tools.in (line 14)) (3.4.1)
Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.12/site-packages (from requests->-r requirements/tools.in (line 14)) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.12/site-packages (from requests->-r requirements/tools.in (line 14)) (2.4.0)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.12/site-packages (from requests->-r requirements/tools.in (line 14)) (2025.1.31)
Requirement already satisfied: sphinxcontrib-applehelp>=1.0.7 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.0.0)
Requirement already satisfied: sphinxcontrib-devhelp>=1.0.6 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.0.0)
Requirement already satisfied: sphinxcontrib-htmlhelp>=2.0.6 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.1.0)
Requirement already satisfied: sphinxcontrib-jsmath>=1.0.1 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (1.0.1)
Requirement already satisfied: sphinxcontrib-qthelp>=1.0.6 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.0.0)
Requirement already satisfied: sphinxcontrib-serializinghtml>=1.1.9 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.0.0)
Requirement already satisfied: snowballstemmer>=2.2 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.2.0)
Requirement already satisfied: babel>=2.13 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (2.17.0)
Requirement already satisfied: alabaster>=0.7.14 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (1.0.0)
Requirement already satisfied: imagesize>=1.3 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (1.4.1)
Requirement already satisfied: roman-numerals-py>=1.0.0 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (3.1.0)
Requirement already satisfied: packaging>=23.0 in /usr/local/lib/python3.12/site-packages (from sphinx->-r requirements/tools.in (line 18)) (24.2)
Requirement already satisfied: beautifulsoup4>=4.8.1 in /usr/local/lib/python3.12/site-packages (from sphinx-codeautolink->-r requirements/tools.in (line 19)) (4.13.3)
Requirement already satisfied: sphinxcontrib-jquery in /usr/local/lib/python3.12/site-packages (from sphinx-hoverxref->-r requirements/tools.in (line 20)) (4.1)
Requirement already satisfied: jsonpointer in /usr/local/lib/python3.12/site-packages (from sphinx-jsonschema->-r requirements/tools.in (line 21)) (3.0.0)
Requirement already satisfied: cachetools>=5.5.1 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (5.5.2)
Requirement already satisfied: chardet>=5.2 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (5.2.0)
Requirement already satisfied: colorama>=0.4.6 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (0.4.6)
Requirement already satisfied: filelock>=3.16.1 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (3.18.0)
Requirement already satisfied: platformdirs>=4.3.6 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (4.3.7)
Requirement already satisfied: pluggy>=1.5 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (1.5.0)
Requirement already satisfied: pyproject-api>=1.8 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (1.9.0)
Requirement already satisfied: virtualenv>=20.29.1 in /usr/local/lib/python3.12/site-packages (from tox->-r requirements/tools.in (line 24)) (20.30.0)
Requirement already satisfied: readme-renderer>=35.0 in /usr/local/lib/python3.12/site-packages (from twine->-r requirements/tools.in (line 25)) (44.0)
Requirement already satisfied: requests-toolbelt!=0.9.0,>=0.8.0 in /usr/local/lib/python3.12/site-packages (from twine->-r requirements/tools.in (line 25)) (1.0.0)
Requirement already satisfied: keyring>=15.1 in /usr/local/lib/python3.12/site-packages (from twine->-r requirements/tools.in (line 25)) (25.6.0)
Requirement already satisfied: rfc3986>=1.4.0 in /usr/local/lib/python3.12/site-packages (from twine->-r requirements/tools.in (line 25)) (2.0.0)
Requirement already satisfied: id in /usr/local/lib/python3.12/site-packages (from twine->-r requirements/tools.in (line 25)) (1.5.0)
Requirement already satisfied: types-pyOpenSSL in /usr/local/lib/python3.12/site-packages (from types-redis->-r requirements/tools.in (line 28)) (24.1.0.20240722)
Requirement already satisfied: cryptography>=35.0.0 in /usr/local/lib/python3.12/site-packages (from types-redis->-r requirements/tools.in (line 28)) (44.0.2)
Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.12/site-packages (from pexpect->-r /hypothesis/requirements/test.in (line 2)) (0.7.0)
Requirement already satisfied: iniconfig in /usr/local/lib/python3.12/site-packages (from pytest->-r /hypothesis/requirements/test.in (line 3)) (2.1.0)
Requirement already satisfied: execnet>=2.1 in /usr/local/lib/python3.12/site-packages (from pytest-xdist->-r /hypothesis/requirements/test.in (line 4)) (2.1.1)
Requirement already satisfied: pyflakes>=3.0.0 in /usr/local/lib/python3.12/site-packages (from autoflake>=1.4->shed==2024.1.1->-r requirements/tools.in (line 17)) (3.3.2)
Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.12/site-packages (from beautifulsoup4>=4.8.1->sphinx-codeautolink->-r requirements/tools.in (line 19)) (2.6)
Requirement already satisfied: pathspec>=0.9.0 in /usr/local/lib/python3.12/site-packages (from black>=24.1.0->shed==2024.1.1->-r requirements/tools.in (line 17)) (0.12.1)
Requirement already satisfied: cffi>=1.12 in /usr/local/lib/python3.12/site-packages (from cryptography>=35.0.0->types-redis->-r requirements/tools.in (line 28)) (1.17.1)
Requirement already satisfied: pytz>=0a in /usr/local/lib/python3.12/site-packages (from feedgenerator>=2.1.0->pelican[markdown]->-r requirements/tools.in (line 10)) (2025.2)
Requirement already satisfied: parso<0.9.0,>=0.8.4 in /usr/local/lib/python3.12/site-packages (from jedi>=0.16->ipython->-r requirements/tools.in (line 5)) (0.8.4)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.12/site-packages (from jinja2>=3.1.2->pelican[markdown]->-r requirements/tools.in (line 10)) (3.0.2)
Requirement already satisfied: SecretStorage>=3.2 in /usr/local/lib/python3.12/site-packages (from keyring>=15.1->twine->-r requirements/tools.in (line 25)) (3.3.3)
Requirement already satisfied: jeepney>=0.4.2 in /usr/local/lib/python3.12/site-packages (from keyring>=15.1->twine->-r requirements/tools.in (line 25)) (0.9.0)
Requirement already satisfied: jaraco.classes in /usr/local/lib/python3.12/site-packages (from keyring>=15.1->twine->-r requirements/tools.in (line 25)) (3.4.0)
Requirement already satisfied: jaraco.functools in /usr/local/lib/python3.12/site-packages (from keyring>=15.1->twine->-r requirements/tools.in (line 25)) (4.1.0)
Requirement already satisfied: jaraco.context in /usr/local/lib/python3.12/site-packages (from keyring>=15.1->twine->-r requirements/tools.in (line 25)) (6.0.1)
Requirement already satisfied: wcwidth in /usr/local/lib/python3.12/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython->-r requirements/tools.in (line 5)) (0.2.13)
Requirement already satisfied: tokenize-rt>=6.1.0 in /usr/local/lib/python3.12/site-packages (from pyupgrade>=3.15.0->shed==2024.1.1->-r requirements/tools.in (line 17)) (6.1.0)
Requirement already satisfied: nh3>=0.2.14 in /usr/local/lib/python3.12/site-packages (from readme-renderer>=35.0->twine->-r requirements/tools.in (line 25)) (0.2.21)
Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.12/site-packages (from rich>=13.6.0->pelican[markdown]->-r requirements/tools.in (line 10)) (3.0.0)
Requirement already satisfied: distlib<1,>=0.3.7 in /usr/local/lib/python3.12/site-packages (from virtualenv>=20.29.1->tox->-r requirements/tools.in (line 24)) (0.3.9)
Requirement already satisfied: anyio>=3.0.0 in /usr/local/lib/python3.12/site-packages (from watchfiles>=0.21.0->pelican[markdown]->-r requirements/tools.in (line 10)) (4.9.0)
Requirement already satisfied: executing>=1.2.0 in /usr/local/lib/python3.12/site-packages (from stack_data->ipython->-r requirements/tools.in (line 5)) (2.2.0)
Requirement already satisfied: asttokens>=2.1.0 in /usr/local/lib/python3.12/site-packages (from stack_data->ipython->-r requirements/tools.in (line 5)) (3.0.0)
Requirement already satisfied: pure-eval in /usr/local/lib/python3.12/site-packages (from stack_data->ipython->-r requirements/tools.in (line 5)) (0.2.3)
Requirement already satisfied: types-cffi in /usr/local/lib/python3.12/site-packages (from types-pyOpenSSL->types-redis->-r requirements/tools.in (line 28)) (1.17.0.20250326)
Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.12/site-packages (from anyio>=3.0.0->watchfiles>=0.21.0->pelican[markdown]->-r requirements/tools.in (line 10)) (1.3.1)
Requirement already satisfied: pycparser in /usr/local/lib/python3.12/site-packages (from cffi>=1.12->cryptography>=35.0.0->types-redis->-r requirements/tools.in (line 28)) (2.22)
Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=13.6.0->pelican[markdown]->-r requirements/tools.in (line 10)) (0.1.2)
Requirement already satisfied: more-itertools in /usr/local/lib/python3.12/site-packages (from jaraco.classes->keyring>=15.1->twine->-r requirements/tools.in (line 25)) (10.6.0)
Requirement already satisfied: types-setuptools in /usr/local/lib/python3.12/site-packages (from types-cffi->types-pyOpenSSL->types-redis->-r requirements/tools.in (line 28)) (78.1.0.20250329)
Obtaining file:///hypothesis/hypothesis-python
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: attrs>=22.2.0 in /usr/local/lib/python3.12/site-packages (from hypothesis==6.127.8) (24.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /usr/local/lib/python3.12/site-packages (from hypothesis==6.127.8) (2.4.0)
Installing collected packages: hypothesis
  Attempting uninstall: hypothesis
    Found existing installation: hypothesis 6.127.8
    Uninstalling hypothesis-6.127.8:
      Successfully uninstalled hypothesis-6.127.8
  Running setup.py develop for hypothesis
Successfully installed hypothesis-6.127.8
3. Run the tests to verify that the change works:
   ============================= test session starts ==============================
platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0 -- /usr/local/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/hypothesis/.hypothesis/examples'))
rootdir: /hypothesis
configfile: pytest.ini
plugins: xdist-3.6.1, anyio-4.9.0, hypothesis-6.127.8
collecting ... collected 1 item

hypothesis-python/tests/ghostwriter/test_ghostwriter.py::test_flattens_multiple_nested_one_of PASSED [100%]

============================= slowest 20 durations =============================

(3 durations < 1s hidden.  Use -vv to show these durations.)
============================== 1 passed in 0.06s ===============================

## Test Output

