### PR TITLE
Flatten multiple one_of strategies recursively

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -76,6 +76,7 @@ their individual contributions.
 * `Grzegorz Zieba <https://github.com/gzaxel>`_ (g.zieba@erax.pl)
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hal Blackburn <https://github.com/h4l>`_
+* `Human Uplift Assistant <https://github.com/human-uplift>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Humberto Rocha <https://github.com/humrochagf>`_
 * `Ilya Lebedev <https://github.com/melevir>`_ (melevir@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+The :func:`~hypothesis.strategies.one_of` strategy now flattens nested :func:`~hypothesis.strategies.one_of` strategies
+to improve the probability distribution of generated values.
+
+This change ensures that when strategies like ``one_of(one_of(a, b), c)`` are used, each of ``a``, ``b``, and ``c``
+will be selected with equal probability, rather than ``a`` and ``b`` sharing half the probability and ``c`` getting
+the other half.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -837,7 +837,19 @@ def one_of(
     # we've handled the case where args is a one-element sequence [(s1, s2, ...)]
     # above, so we can assume it's an actual sequence of strategies.
     args = cast(Sequence[SearchStrategy], args)
-    return OneOfStrategy(args)
+    
+    # Flatten nested one_of strategies recursively
+    def flatten_strategies(strats):
+        result = []
+        for strat in strats:
+            if isinstance(strat, OneOfStrategy):
+                result.extend(flatten_strategies(strat.original_strategies))
+            else:
+                result.append(strat)
+        return result
+    
+    flattened_strategies = flatten_strategies(args)
+    return OneOfStrategy(flattened_strategies)
 
 
 class MappedStrategy(SearchStrategy[MappedTo], Generic[MappedFrom, MappedTo]):

--- a/hypothesis-python/tests/cover/test_one_of_flattening.py
+++ b/hypothesis-python/tests/cover/test_one_of_flattening.py
@@ -1,0 +1,49 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from hypothesis.strategies import just, one_of
+from hypothesis.strategies._internal.strategies import OneOfStrategy
+
+
+def test_one_of_flattens_single_level():
+    # Test that one_of(one_of(just(1), just(2)), just(3)) becomes equivalent to
+    # one_of(just(1), just(2), just(3))
+    s1 = one_of(just(1), just(2))
+    s2 = just(3)
+    s = one_of(s1, s2)
+    
+    assert isinstance(s, OneOfStrategy)
+    assert len(s.original_strategies) == 3
+    assert all(strat.value == i for i, strat in enumerate(s.original_strategies, 1))
+
+
+def test_one_of_flattens_multiple_levels():
+    # Test that deeply nested one_of calls are flattened
+    s1 = one_of(just(1), just(2))
+    s2 = one_of(just(3), one_of(just(4), just(5)))
+    s3 = one_of(s1, s2)
+    s = one_of(s3, just(6))
+    
+    assert isinstance(s, OneOfStrategy)
+    assert len(s.original_strategies) == 6
+    assert all(strat.value == i for i, strat in enumerate(s.original_strategies, 1))
+
+
+def test_one_of_maintains_order():
+    # Test that the order of strategies is maintained after flattening
+    s1 = one_of(just(1), just(2))
+    s2 = one_of(just(3), just(4))
+    s = one_of(s1, s2)
+    
+    assert isinstance(s, OneOfStrategy)
+    assert len(s.original_strategies) == 4
+    assert all(strat.value == i for i, strat in enumerate(s.original_strategies, 1))


### PR DESCRIPTION
This PR implements recursive flattening of nested one_of strategies to ensure that each sub-strategy is selected with equal probability.

## Problem
Currently, when using nested one_of strategies like one_of(one_of(a, b), c), the probability of selecting sub-strategies is not evenly distributed. In this example, a and b together get 50% probability, while c gets the other 50%, making each of a and b having only a 25% chance of being selected.

## Solution
This PR modifies the one_of function to recursively flatten nested one_of strategies, so that in the example above, all three strategies a, b, and c would each have a 33.3% chance of being selected.

## Testing
Added tests that verify:
1. Single-level flattening works correctly
2. Multiple-level deep nesting is flattened properly
3. The order of strategies is maintained during flattening

All existing tests continue to pass, including those specifically designed to test the distribution of one_of strategies.

## Test Output



## How to Test
1. Install the package: pip install -e hypothesis-python/
2. Run the test suite: python -m pytest hypothesis-python/tests/cover/test_one_of_flattening.py -v
3. You can also try it interactively:
